### PR TITLE
fix pg tls issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/bunyan": "1.8.0",
     "@types/elasticsearch": "^5.0.16",
     "@types/mocha": "^2.2.41",
-    "@types/pg": "^6.1.45",
+    "@types/pg": "6.1.45",
     "amqplib": "^0.5.2",
     "aws-sdk": "^2.102.0",
     "axios": "^0.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,10 +37,6 @@
   version "5.0.16"
   resolved "https://registry.yarnpkg.com/@types/elasticsearch/-/elasticsearch-5.0.16.tgz#fc29dc26c894aed69a6d20390d3c736aad61e625"
 
-"@types/events@*":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@types/events/-/events-1.1.0.tgz#93b1be91f63c184450385272c47b6496fd028e02"
-
 "@types/fs-extra@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-4.0.0.tgz#1dd742ad5c9bce308f7a52d02ebc01421bc9102f"
@@ -101,11 +97,10 @@
   dependencies:
     moment ">=2.14.0"
 
-"@types/pg@^6.1.45":
-  version "6.1.46"
-  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-6.1.46.tgz#4bca3cb605181eabd54e145aea33ff22d9ca3f80"
+"@types/pg@6.1.45":
+  version "6.1.45"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-6.1.45.tgz#bfca89900b4abb506e233575a49d41e3d1c83029"
   dependencies:
-    "@types/events" "*"
     "@types/node" "*"
     "@types/pg-types" "*"
 


### PR DESCRIPTION
It has to be an exact version to fix the tls error

`error TS2305: Module '"tls"' has no exported member 'TlsServerOptions'`