### PR TITLE
Add support for globs to addDirectory interface

### DIFF
--- a/docs/REGISTERING_COMPONENTS.md
+++ b/docs/REGISTERING_COMPONENTS.md
@@ -1,0 +1,134 @@
+# Registering Components
+
+## Introduction
+
+While you were going through the [Getting Started](GETTING_STARTED.md) section, you already learnt 
+that we need to tell inceptum about the controllers and services before we write them. 
+
+In this section, we will describe different ways of registering such components with inceptum.
+
+There are two basic approaches to do this. 
+
+### Approach 1: Provide the directory url 
+The first way is trivial. Provide inceptum with the directory name and inceptum will recursively travel 
+through the directory to register all modules in that directory. 
+
+```js
+app.addDirectory(path.resolve(`${__dirname}/controller`));
+```
+
+In fact, this is the approach we followed
+in the [Getting Started](GETTING_STARTED.md) section. 
+
+However, this approach can be troublesome, if you decide to mix your controllers or services with other 
+modules. 
+
+For instance, if you decide to keep your tests alongside the source files, inceptum will assume
+the tests as source files. 
+
+```
+controller
+├── JobController.ts
+├── PageController.ts
+├── SalesController.ts
+└── __tests__
+    ├── JobController.test.js
+    ├── PageController.test.js
+    └── SalesController.test.js
+```
+
+Another scenario is when you follow a component based architecture and decide to
+keep all related services, controllers, views etc. together in a directory.
+
+```
+modules
+├── job
+│   ├── config
+│   ├── jobController
+│   ├── jobService
+│   └── jobView
+├── page
+│   ├── config
+│   ├── pageController
+│   ├── pageService
+│   └── pageView
+└── sales
+│   ├── config
+│   ├── salesController
+│   ├── salesService
+│   └── salesView
+```
+
+Thus inceptum now supports glob patterns for the `addDirectory` method, allowing you to tackle these scenarios.
+
+### Approach 2: Glob Patterns
+ 
+To address these problems, we introduced glob pattern matching to the `addDirectory` method. 
+Thus for the above example scenarios, we can use the following commands to match only the controllers.
+
+*Please see the Advanced Usage section for more details on how to use glob patterns.*
+
+##### Ignore recursive `__test__` directories
+```js
+app.addDirectory([
+    path.resolve(`${__dirname}/controller`), 
+    '!**/__test__'
+]);
+```
+
+##### Match only controllers
+```js
+app.addDirectory(path.resolve(`${__dirname}/modules/**/*Controller.js`))
+```
+
+## Advanced usage
+
+In above examples, how did we instruct inceptum to use direct matching, or glob pattern matching? 
+Well, there are few ways to tell inceptum about the approach it should take. 
+
+### Conventions
+Most of the times, Inceptum is intelligent enough to pick the suitable approach for pattern matching based on first argument you
+supply to the `addDirectory` method. The available conventions can be listed down as follows,
+
+Note that the conventions are purely based on the first argument, i.e. `path` argument of the `addDirectory` method,
+
+1. When the path is a string, and contains at least one of the magic characters={}, then inceptum will treat it 
+as a glob pattern.
+1. When the argument is an array of strings, then inceptum will treat all the string patterns as glob patterns.
+1. When the argument is a string, and does not contain any magic characters, then inceptum will treat the path
+as a normal string path. *Here, you can force inceptum to treat the path as a glob using the `isGlob` option as
+explained in the next section.*
+
+##### Here is a quick overview of the magic characters and their usage
+
+* `*` matches any number of characters, but not /
+* `?` matches a single character, but not /
+* `**` matches any number of characters, including /, as long as it's the only thing in a path part
+* `{}` allows for a comma-separated list of "or" expressions
+* `!` at the beginning of a pattern will negate the match
+
+
+### isGlob option
+The `addDirectory` method takes an optional options argument to configure its usage. The `isGlob` attribute can
+be used to force inceptum to treat the path as a glob. However, it is usually not required to do so. You might
+need to think twice before using this option. Anyways, the usage is as follows,
+
+```js
+app.addDirectory(path.resolve(`${__dirname}/controller`), { 
+    isGlob: true 
+});
+```
+
+### Customizing glob matching
+Inceptum internally uses the `npm globby` library to do glob matching. Thus, we allow configuring the `globby`
+usage via the second argument of the `addDirectory` method. The usage is as follows,
+
+```js
+app.addDirectory(path.resolve(`${__dirname}/modules/**/*Controller.js`), { 
+    globOptions: {
+        gitignore: true // Respect ignore patterns in .gitignore files that apply to the globbed files.
+    }
+});
+```
+
+See the [https://github.com/sindresorhus/globby#options](globby options) to see more details on globOptions available.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,4 +2,5 @@
 
 * [Introduction](README.md)
 * [Getting Started](GETTING_STARTED.md)
+* [Registering Components](REGISTERING_COMPONENTS.md)
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "express-yields": "^1.0.0",
     "generic-pool": "^3.4.2",
     "gh-pages": "^1.0.0",
+    "globby": "^8.0.1",
     "js-yaml": "^3.9.1",
     "json-schema-deref-sync": "^0.3.1",
     "json-stringify-safe": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "mocha": "^2.5.3",
     "mocha-lcov-reporter": "^1.2.0",
     "mocha-typescript": "1.1.2",
+    "mock-fs": "^4.4.2",
     "must": "^0.13.4",
     "nyc": "^11.1.0",
     "semantic-release": "^15.1.7",

--- a/src/app/BaseApp.ts
+++ b/src/app/BaseApp.ts
@@ -75,8 +75,29 @@ export default class BaseApp {
     return this.register(...plugins);
   }
 
-  public addDirectory(path) {
-    return this.getContext().registerSingletonsInDir(path);
+
+  /**
+   * Register services or controllers with Inceptum
+   * Note that we are using "npm globby" internally for glob matching.
+   *
+   * Globs are disabled by default. Pass isGlob=true to enable glob matching
+   *
+   * Globs will be automatically activated if the "patterns" parameter is an array of strings,
+   * or if it contains magic characters (eg: * ? { })
+   *
+   * @param {string|Array<string>} patterns - path as a relative path or as glob pattern(s). See options for more details
+   * @param {Object} [options] - options object for enabling and configuring glob matching
+   * @param {boolean} [options.isGlob=false] - pass true to treat the path as a glob
+   * @param {Object} [options.globOptions] - options to pass to globby
+   */
+  public addDirectory(patterns: string | Array<string>, options: {
+    isGlob: boolean,
+    globOptions: Object,
+  } = {
+    isGlob: false,
+    globOptions: {},
+  }) {
+    return this.getContext().registerSingletonsInDir(patterns, options);
   }
 
   public register(...plugins: PluginImplemenation[]) {

--- a/src/ioc/Context.ts
+++ b/src/ioc/Context.ts
@@ -4,7 +4,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import globby from 'globby';
+import * as globby from 'globby';
 import Config, { ConfigAdapter } from '../config/ConfigProvider';
 import { Logger, LogManager } from '../log/LogManager';
 import { PromiseUtil } from '../util/PromiseUtil';

--- a/src/ioc/Context.ts
+++ b/src/ioc/Context.ts
@@ -163,7 +163,7 @@ export class Context extends Lifecycle {
   }
 
   registerSingletonsInDir(patterns, options) {
-    Context.walkDir(patterns, options).filter((file) => ['.js', '.ts'].indexOf(path.extname(file)) >= 0).forEach((file) => {
+    Context.findMatchingFiles(patterns, options).filter((file) => ['.js', '.ts'].indexOf(path.extname(file)) >= 0).forEach((file) => {
       if (file.includes('.d.ts')) {
         return; // Ignore type definition files
       }
@@ -190,7 +190,7 @@ export class Context extends Lifecycle {
   }
 
   static requireFilesInDir(dir) {
-    Context.walkDirLegacy(dir).filter((file) => path.extname(file) === '.js').forEach((file) => {
+    Context.walkDir(dir).filter((file) => path.extname(file) === '.js').forEach((file) => {
       // eslint-disable-next-line global-require
       require(file);
     });
@@ -204,24 +204,24 @@ export class Context extends Lifecycle {
    * @param filelist The carried-over list of files
    * @return {Array} The list of files in this directory and subdirs
    */
-  static walkDirLegacy(dir, filelist = []) {
+  static walkDir(dir, filelist = []) {
     fs.readdirSync(dir).forEach((file) => {
       filelist = fs.statSync(path.join(dir, file)).isDirectory()
-        ? Context.walkDirLegacy(path.join(dir, file), filelist)
+        ? Context.walkDir(path.join(dir, file), filelist)
         : filelist.concat(path.join(dir, file));
     });
     return filelist;
   }
 
   /**
-   * Async version of walkDirLegacy additionally infused with glob matching
+   *  find matching files based on the given path or glob
    *
    * @param {string} patterns - glob pattern(s) or relative path
    * @param {boolean} [isGlob=false] - pass true to treat the path as a glob
    * @param {Object} [globOptions={}] - options to pass to globby
    * @returns {Array<string>} files
    */
-  static walkDir(patterns: string | Array<string>, {isGlob, globOptions}: {
+  static findMatchingFiles(patterns: string | Array<string>, {isGlob, globOptions}: {
     isGlob: boolean,
     globOptions: Object,
   }): Array<string> {
@@ -232,7 +232,7 @@ export class Context extends Lifecycle {
     }
 
     // Fallback to the legacy implementation for non-glob patterns to avoid code breaks
-    return Context.walkDirLegacy(patterns);
+    return Context.walkDir(patterns);
   }
 
   // ************************************

--- a/src/ioc/Context.ts
+++ b/src/ioc/Context.ts
@@ -190,7 +190,7 @@ export class Context extends Lifecycle {
   }
 
   static requireFilesInDir(dir) {
-    Context.walkDir(dir).filter((file) => path.extname(file) === '.js').forEach((file) => {
+    Context.walkDirSync(dir).filter((file) => path.extname(file) === '.js').forEach((file) => {
       // eslint-disable-next-line global-require
       require(file);
     });
@@ -204,10 +204,10 @@ export class Context extends Lifecycle {
    * @param filelist The carried-over list of files
    * @return {Array} The list of files in this directory and subdirs
    */
-  static walkDir(dir, filelist = []) {
+  static walkDirSync(dir, filelist = []) {
     fs.readdirSync(dir).forEach((file) => {
       filelist = fs.statSync(path.join(dir, file)).isDirectory()
-        ? Context.walkDir(path.join(dir, file), filelist)
+        ? Context.walkDirSync(path.join(dir, file), filelist)
         : filelist.concat(path.join(dir, file));
     });
     return filelist;
@@ -235,7 +235,7 @@ export class Context extends Lifecycle {
     }
 
     // Fallback to the legacy implementation for non-glob patterns to avoid code breaks
-    return Context.walkDir(patterns);
+    return Context.walkDirSync(patterns);
   }
 
   // ************************************

--- a/src/ioc/Context.ts
+++ b/src/ioc/Context.ts
@@ -217,16 +217,13 @@ export class Context extends Lifecycle {
    *  find matching files based on the given path or glob
    *
    * @param {string} patterns - glob pattern(s) or relative path
-   * @param {boolean} [isGlob=false] - pass true to treat the path as a glob
+   * @param {boolean} [isGlob] - pass true to treat the path as a glob
    * @param {Object} [globOptions] - options to pass to globby
    * @returns {Array<string>} files
    */
   static findMatchingFiles(patterns: string | Array<string>, {isGlob, globOptions}: {
     isGlob: boolean,
     globOptions: Object,
-  } = {
-    isGlob: false,
-    globOptions: {},
   }): Array<string> {
 
     // Try to treat the patterns as globs first

--- a/src/ioc/Context.ts
+++ b/src/ioc/Context.ts
@@ -218,12 +218,15 @@ export class Context extends Lifecycle {
    *
    * @param {string} patterns - glob pattern(s) or relative path
    * @param {boolean} [isGlob=false] - pass true to treat the path as a glob
-   * @param {Object} [globOptions={}] - options to pass to globby
+   * @param {Object} [globOptions] - options to pass to globby
    * @returns {Array<string>} files
    */
   static findMatchingFiles(patterns: string | Array<string>, {isGlob, globOptions}: {
     isGlob: boolean,
     globOptions: Object,
+  } = {
+    isGlob: false,
+    globOptions: {},
   }): Array<string> {
 
     // Try to treat the patterns as globs first

--- a/test/app/BaseApp.ts
+++ b/test/app/BaseApp.ts
@@ -1,4 +1,4 @@
-import {when, spy, capture, anything} from 'ts-mockito';
+import {when, spy, capture, anything, reset} from 'ts-mockito';
 import BaseApp from '../../src/app/BaseApp';
 import {Context} from '../../src';
 
@@ -20,6 +20,8 @@ describe('BaseApp', () => {
           globOptions: {},
         },
       ]);
+
+      reset(spiedContext);
     });
     it('calls findMatchingFiles with given arguments', () => {
       const app = new BaseApp();
@@ -44,6 +46,8 @@ describe('BaseApp', () => {
           },
         },
       ]);
+
+      reset(spiedContext);
     });
   });
 });

--- a/test/app/BaseApp.ts
+++ b/test/app/BaseApp.ts
@@ -1,0 +1,49 @@
+import {when, spy, capture, anything} from 'ts-mockito';
+import BaseApp from '../../src/app/BaseApp';
+import {Context} from '../../src';
+
+describe('BaseApp', () => {
+  describe('addDirectory method', () => {
+    it('calls findMatchingFiles with default arguments', () => {
+      const app = new BaseApp();
+      const spiedContext = spy(Context);
+
+      when(spiedContext.findMatchingFiles(anything(), anything())).thenReturn([]);
+
+      app.addDirectory('src/**/*.js');
+
+      const lastCall = capture(spiedContext.findMatchingFiles).last();
+      lastCall.must.eql([
+        'src/**/*.js',
+        {
+          isGlob: false,
+          globOptions: {},
+        },
+      ]);
+    });
+    it('calls findMatchingFiles with given arguments', () => {
+      const app = new BaseApp();
+      const spiedContext = spy(Context);
+
+      when(spiedContext.findMatchingFiles(anything(), anything())).thenReturn([]);
+
+      app.addDirectory('src/**/*.js', {
+        isGlob: true,
+        globOptions: {
+          gitignore: true,
+        },
+      });
+
+      const lastCall = capture(spiedContext.findMatchingFiles).last();
+      lastCall.must.eql([
+        'src/**/*.js',
+        {
+          isGlob: true,
+          globOptions: {
+            gitignore: true,
+          },
+        },
+      ]);
+    });
+  });
+});

--- a/test/ioc/Context.ts
+++ b/test/ioc/Context.ts
@@ -522,6 +522,12 @@ suite('ioc/Context', () => {
     });
   });
   suite('findMatchingFiles', () => {
+
+    const options = {
+      isGlob: false,
+      globOptions: {},
+    };
+
     beforeEach(() => {
       mockFS({
         src: {
@@ -586,7 +592,7 @@ suite('ioc/Context', () => {
     });
 
     test('recursively matches files, given a simple path', () => {
-      const files = Context.findMatchingFiles('src/services');
+      const files = Context.findMatchingFiles('src/services', options);
       [
         'src/services/jobService.js',
         'src/services/subServices/repeatJobService.js',
@@ -595,7 +601,7 @@ suite('ioc/Context', () => {
       });
     });
     test('ignores a directory decorated with negation', () => {
-      const files = Context.findMatchingFiles(['src/controllers', '!src/controllers/__tests__']);
+      const files = Context.findMatchingFiles(['src/controllers', '!src/controllers/__tests__'], options);
       [
         'src/controllers/jobController.js',
         'src/controllers/messageController.js',
@@ -605,7 +611,7 @@ suite('ioc/Context', () => {
       });
     });
     test('only matches files for glob pattern', () => {
-      const files = Context.findMatchingFiles('src/modules/**/*Controller.js');
+      const files = Context.findMatchingFiles('src/modules/**/*Controller.js', options);
       [
         'src/modules/job/jobController.js',
         'src/modules/message/messageController.js',
@@ -615,7 +621,7 @@ suite('ioc/Context', () => {
       });
     });
     test('recursively match glob pattern', () => {
-      const files = Context.findMatchingFiles(['src/**/*.js', '!src/**/*.test.js']);
+      const files = Context.findMatchingFiles(['src/**/*.js', '!src/**/*.test.js'], options);
       [
         'src/services/jobService.js',
         'src/services/subServices/repeatJobService.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2965,6 +2965,18 @@ globby@^8.0.0:
     pify "^3.0.0"
     slash "^1.0.0"
 
+globby@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-8.0.1.tgz#b5ad48b8aa80b35b814fc1281ecc851f1d2b5b50"
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    fast-glob "^2.0.2"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
+
 got@^6.7.1:
   version "6.7.1"
   resolved "https://registry.npmjs.org/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2953,19 +2953,7 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-globby@^8.0.0:
-  version "8.0.1"
-  resolved "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz#b5ad48b8aa80b35b814fc1281ecc851f1d2b5b50"
-  dependencies:
-    array-union "^1.0.1"
-    dir-glob "^2.0.0"
-    fast-glob "^2.0.2"
-    glob "^7.1.2"
-    ignore "^3.3.5"
-    pify "^3.0.0"
-    slash "^1.0.0"
-
-globby@^8.0.1:
+globby@^8.0.0, globby@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/globby/-/globby-8.0.1.tgz#b5ad48b8aa80b35b814fc1281ecc851f1d2b5b50"
   dependencies:
@@ -4806,6 +4794,10 @@ mocha@^2.5.3:
     mkdirp "0.5.1"
     supports-color "1.2.0"
     to-iso-string "0.0.2"
+
+mock-fs@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.4.2.tgz#09dec5313f97095a450be6aa2ad8ab6738d63d6b"
 
 modify-values@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This allows to call the addDirectory method as follows,

`server.addDirectory([path.join(base, 'server', 'controllers', '/**/*'), '!**/__test__']);`