### PR TITLE
Fix: move the retry count definition to the client class and initiali…

### DIFF
--- a/src/rabbitmq/RabbitmqClient.ts
+++ b/src/rabbitmq/RabbitmqClient.ts
@@ -71,6 +71,12 @@ export abstract class RabbitmqClient {
     await this.connect();
   }
 
+  static getDefaultHeader(): any {
+    return {
+        retriesCount: 0,
+    };
+  }
+
   /**
    * Connect to RabbitMQ broker
    */

--- a/src/rabbitmq/RabbitmqConsumer.ts
+++ b/src/rabbitmq/RabbitmqConsumer.ts
@@ -111,6 +111,9 @@ export class RabbitmqConsumer extends RabbitmqClient {
       this.logger.error(e, 'failed to handle message');
       this.consumeFailures.inc();
       NewrelicUtil.noticeError(e, message);
+      if (!message.properties.headers) {
+        message.properties.headers = RabbitmqClient.getDefaultHeader();
+      }
       const retriesCount = ++message.properties.headers.retriesCount;
       if (e instanceof RabbitmqConsumerHandlerUnrecoverableError || !this.allowRetry(retriesCount)) {
         // add to dlq

--- a/src/rabbitmq/RabbitmqProducer.ts
+++ b/src/rabbitmq/RabbitmqProducer.ts
@@ -47,9 +47,7 @@ export class RabbitmqProducer extends RabbitmqClient {
         if (!this.readyGate.isChannelReady()) {
             await this.readyGate.awaitChannelReady();
         }
-        optionsPublish.headers = {
-            retriesCount: 0,
-        };
+        optionsPublish.headers = RabbitmqClient.getDefaultHeader();
         const timer = this.publishDurationHistogram.startTimer();
         try {
             while (!this.channel.publish(this.producerConfig.exchangeName, routingKey, new Buffer(msg), optionsPublish)) {


### PR DESCRIPTION
…ze the retryCount variable on the consumer if it's not set. It's usually not set when a message is queued via the php sdk