### PR TITLE
fixed routes when there's more than one controller

### DIFF
--- a/src/web/WebRoutingInspector.ts
+++ b/src/web/WebRoutingInspector.ts
@@ -40,7 +40,7 @@ export class WebRoutingInspector extends AbstractObjectDefinitionInspector {
 
   private processRoutes(routes: InceptumWebRouteMetadata[], objectDefinition) {
     routes.forEach((route, index) => {
-      const instanceName = `instance_${index}`;
+      const instanceName = `instance_${objectDefinition.getName()}_${index}`;
       this.routesToRegister.push(
         {
           verb: route.verb || 'get',


### PR DESCRIPTION
Turns out that when there's more than one class using a @WebDecorator decorator to define routes. The Decorator inspector was getting confused and overwriting them. This fix makes the routes work as expected.