### PR TITLE
Added BaseApp to exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { SingletonDefinition } from './ioc/objectdefinition/SingletonDefinition'
 export { PreinstantiatedSingletonDefinition } from './ioc/objectdefinition/PreinstantiatedSingletonDefinition';
 export { BaseSingletonDefinition } from './ioc/objectdefinition/BaseSingletonDefinition';
 export { InceptumApp, TestInceptumApp } from './app/InceptumApp';
+export { default as BaseApp } from './app/BaseApp';
 export * from './log/LogManager';
 export { ExtendedError } from './util/ErrorUtil';
 export { BadRequestError } from './web/errors/BadRequestError';


### PR DESCRIPTION
When creating a custom plugin in an Inceptum App (outside of inceptum core), the signature of the plugin methods reference the type BaseApp, but this type is not exposed anywhere, so it makes it harder to write a well typed method in a plugin.

This patch exposes the BaseApp object