### PR TITLE
feat: Add a "stopping" time

### DIFF
--- a/src/app/BaseApp.ts
+++ b/src/app/BaseApp.ts
@@ -45,6 +45,7 @@ export type PluginImplemenation = PluginNameable & PluginImplementsAtLeastOneMet
 export interface AppOptions {
   logger?: Logger,
   config?: ConfigAdapter,
+  shutdownTimer?: number,
 }
 
 export type PluginContext = Map<String | Symbol, any>;
@@ -61,7 +62,7 @@ export default class BaseApp {
    * Creates a new Inceptum App
    */
   constructor(options: AppOptions = {}) {
-    const { config = new Config() } = options;
+    const { config = new Config(), shutdownTimer = 100 } = options;
     const { logger = LogManager.getLogger(__filename) } = options;
     this.logger = logger;
     this.logger.info(`Using app name ${LogManager.getAppName()}`);

--- a/src/app/InceptumApp.ts
+++ b/src/app/InceptumApp.ts
@@ -24,6 +24,7 @@ export const DEFAULT_INCEPTUM_APP_OPTIONS: InceptumAppOptions = {
   enableAdminPort: true,
   enableHealthChecks: true,
   enableMetrics: true,
+  shutdownTimer: process.env.NODE_ENV === 'production' ? 20000 : 200,
 };
 
 export class InceptumApp extends BaseApp {

--- a/src/health/ContextReadyHealthCheck.ts
+++ b/src/health/ContextReadyHealthCheck.ts
@@ -27,7 +27,7 @@ export class ContextReadyHealthCheck extends HealthCheck {
     } else if (contextStatus === LifecycleState.STARTED) {
       return new HealthCheckResult(HealthCheckStatus.OK, `Context STARTED`);
     } else {
-      return new HealthCheckResult(HealthCheckStatus.WARNING, `Context STOPPING`);
+      return new HealthCheckResult(HealthCheckStatus.STOPPING, `Context STOPPING`);
     }
   }
 }

--- a/src/health/HealthCheck.ts
+++ b/src/health/HealthCheck.ts
@@ -15,6 +15,7 @@ export enum HealthCheckStatus {
   NOT_READY = 'NOT_READY', // Used when plugin is starting.
   WARNING = 'WARNING', // Used when plugin is stopping.
   CRITICAL = 'CRITICAL', // Used when issues are found after ready.
+  STOPPING = 'STOPPING', // Used when the app is stopping - everything is ok, but no new requests should be sent
 }
 
 export enum HealthCheckType {
@@ -24,7 +25,7 @@ export enum HealthCheckType {
 }
 
 function getStatusIndex(status: HealthCheckStatus) {
-  return [HealthCheckStatus.OK, HealthCheckStatus.NOT_READY, HealthCheckStatus.WARNING, HealthCheckStatus.CRITICAL].indexOf(status);
+  return [HealthCheckStatus.OK, HealthCheckStatus.NOT_READY, HealthCheckStatus.WARNING, HealthCheckStatus.CRITICAL, HealthCheckStatus.STOPPING].indexOf(status);
 }
 
 export class HealthCheckResult {

--- a/src/ioc/Context.ts
+++ b/src/ioc/Context.ts
@@ -39,7 +39,7 @@ export class Context extends Lifecycle {
   constructor(name: string, parentContext?: Context, options: ContextOptions = {}) {
     super(name, options.logger || LogManager.getLogger(__filename));
     this.config = options.config || new Config();
-    this.shutdownTimer = options.shutdownTimer || 10000;
+    this.shutdownTimer = options.shutdownTimer || 100;
     this.parentContext = parentContext;
     this.objectDefinitions = new Map();
     this.startedObjects = new Map();
@@ -87,7 +87,7 @@ export class Context extends Lifecycle {
   }
 
   protected async doStop(): Promise<any> {
-    this.getLogger().debug(`Waiting ${this.shutdownTimer} to stop context`);
+    this.getLogger().debug(`Waiting ${this.shutdownTimer}ms to stop context`);
     await PromiseUtil.sleepPromise(this.shutdownTimer);
     return PromiseUtil.map(Array.from(this.startedObjects.values()), (startedObject) =>
       startedObject.lcStop(),

--- a/src/web/AdminPortPlugin.ts
+++ b/src/web/AdminPortPlugin.ts
@@ -33,7 +33,7 @@ export default class AdminPortPlugin implements Plugin {
     pluginContext.set(AdminPortPlugin.CONTEXT_SERVER_KEY, server);
   }
 
-  willStop(app, pluginContext) {
+  didStop(app, pluginContext) {
     const express = pluginContext.get(AdminPortPlugin.CONTEXT_SERVER_KEY);
     app.logger.info('Shutting down admin server');
     express.close();

--- a/src/web/WebPlugin.ts
+++ b/src/web/WebPlugin.ts
@@ -143,7 +143,7 @@ export default class WebPlugin implements Plugin {
     pluginContext.set(WebPlugin.CONTEXT_SERVER_KEY, server);
   }
 
-  willStop(app, pluginContext) {
+  didStop(app, pluginContext) {
     const express = pluginContext.get(WebPlugin.CONTEXT_SERVER_KEY);
     app.logger.info('Shutting down server');
     if (express) {


### PR DESCRIPTION
Currently, as soon as you call app.stop(), we almost immediately close the servers and drain the connection pools. This can cause any inflight requests to fail. This PR introduces a shutdown timer. After stop is called, the app will start responding as not ready so no new requests should be sent, but we wait default 20 seconds before we shut everything down.