### PR TITLE
feat: Bind express req and res to controller, before calling the controller handler

### DIFF
--- a/src/swagger/SwaggerRouterMiddleware.ts
+++ b/src/swagger/SwaggerRouterMiddleware.ts
@@ -137,6 +137,8 @@ export default class SwaggerRouterMiddleware {
     paramFunctions.push((req) => req);
     paramFunctions.push((req, res) => res);
     return (req, res) => {
+      controller.req = req;
+      controller.res = res;
       const args = paramFunctions.map((f) => f(req, res));
       return controller[functionName](...args);
     };


### PR DESCRIPTION
With this change, a controller method will look much simpler.

Before:
```js
async get(id, req, res) {
    try {
      const result = await this.leadRecords.insert(id);
      res.json(result);
    } catch (e) {
      // Allows users to handle the error as they want
      res.status(500).json('Internal Server Error');
    }
}
```

After:
```js
async get(id) {
    await this.json(() => this.leadRecords.insert(id));
}
```