### PR TITLE
feat: remove locutus

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "json-schema-deref-sync": "^0.3.1",
     "json-stringify-safe": "5.0.1",
     "jsonwebtoken": "^8.1.1",
-    "locutus": "^2.0.5",
     "lodash": "^4.17.4",
     "module-alias": "2.0.0",
     "moment": "^2.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4127,10 +4127,6 @@ lockfile@~1.0.1, lockfile@~1.0.2, lockfile@~1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz#2638fc39a0331e9cac1a04b71799931c9c50df79"
 
-locutus@^2.0.5:
-  version "2.0.9"
-  resolved "https://registry.npmjs.org/locutus/-/locutus-2.0.9.tgz#e265af1e85fd19173e74386373888560783a02fc"
-
 lodash-compat@^3.10.0:
   version "3.10.2"
   resolved "https://registry.npmjs.org/lodash-compat/-/lodash-compat-3.10.2.tgz#c6940128a9d30f8e902cd2cf99fd0cba4ecfc183"


### PR DESCRIPTION
The locutus@2.0.05 have a security issue, and locutus are not used by the [inceptum](https://github.com/hipages/inceptum)
, let's just remove it.